### PR TITLE
Update/latest aws sdk go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7
+FROM golang:1.8
 
 ENV GOPATH /go
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: b9cb2ad02838aeb3aa3ab5804313e86913512d4c0ef2dfe2df087b94fdd0d83b
-updated: 2016-09-07T22:31:11.582494502+09:00
+updated: 2017-03-19T17:43:36.134181864+09:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: bc572378d109481c50d45d9dba4490d80386e98e
+  version: 5b99715ae2945a2434a2371f4e6c5542e839a32d
   subpackages:
   - aws
   - aws/awserr
@@ -16,10 +16,10 @@ imports:
   - aws/credentials/stscreds
   - aws/defaults
   - aws/ec2metadata
+  - aws/endpoints
   - aws/request
   - aws/session
   - aws/signer/v4
-  - private/endpoints
   - private/protocol
   - private/protocol/ec2query
   - private/protocol/query
@@ -30,17 +30,17 @@ imports:
   - service/ec2
   - service/sts
 - name: github.com/BurntSushi/toml
-  version: 99064174e013895bbd9b025c31100bd1d9b590ca
+  version: d94612f9fc140360834f9742158c70b5c5b5535b
 - name: github.com/codegangsta/cli
-  version: c723b19a84af34d905773672ffa1b8ead802e505
+  version: 9e5b04886c4bfee2ceba1465b8121057355c4e53
 - name: github.com/go-ini/ini
-  version: 6e4869b434bd001f6983749881c7ead3545887d8
+  version: 1730955e3146956d6a087861380f9b4667ed5071
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/mattn/go-runewidth
-  version: d6bea18f789704b5f83375793155289da36a3c7f
+  version: 14207d285c6c197daabb5c9793d63e7af9ab2d50
 - name: github.com/nsf/termbox-go
-  version: e8f6d27f72a2f2bb598eb3579afd5ea364ef67f7
+  version: 91bae1bb5fa9ee504905ecbe7043fa30e92feaa3
 - name: github.com/reiki4040/cstore
   version: 3a1ef96c2022baf3c870e97670f8bb392929d935
 - name: github.com/reiki4040/peco
@@ -48,5 +48,5 @@ imports:
   subpackages:
   - keyseq
 - name: gopkg.in/yaml.v2
-  version: e4d366fc3c7938e2958e662b4258c7a89e1f0e3e
+  version: a3f3340b5840cee44f372bddb5880fcbc419b46a
 testImports: []


### PR DESCRIPTION
- glide up and updated libraries
- Go 1.8