### PR TITLE
fixed version format for homebrew version

### DIFF
--- a/gen_brew_pr.sh
+++ b/gen_brew_pr.sh
@@ -43,13 +43,11 @@ function main() {
   if [ $? == 1 ]; then
     # replace version and sha256 (version is homebrew variable. so do not use '=')
 	# version format is not allow v prefix (NG: v0.1.0, OK: 0.1.0)
-    v=${ver/v/}
-    cat rnzoo.rb | sed -e "s/version \".*\"/version \"${v}\"/" | sed -e "s/normal_sha256 = \".*\"/normal_sha256 = \"${s256}\"/" > rnzoo.rb.new
+    cat rnzoo.rb | sed -e "s/version \".*\"/version \"${ver}\"/" | sed -e "s/normal_sha256 = \".*\"/normal_sha256 = \"${s256}\"/" > rnzoo.rb.new
   else
     # replace devel_version and sha256
     # version format is not allow v prefix (NG: v0.1.0-dev1, OK: 0.1.0-dev1)
-    v=${ver/v/}
-    cat rnzoo.rb | sed -e "s/devel_version = \".*\"/devel_version = \"${v}\"/" | sed -e "s/devel_sha256 = \".*\"/devel_sha256 = \"${s256}\"/" > rnzoo.rb.new
+    cat rnzoo.rb | sed -e "s/devel_version = \".*\"/devel_version = \"${ver}\"/" | sed -e "s/devel_sha256 = \".*\"/devel_sha256 = \"${s256}\"/" > rnzoo.rb.new
   fi
 
   mv rnzoo.rb.new rnzoo.rb


### PR DESCRIPTION
homebrew version does not allow prefix 'v'
so changed git tag format like this:'v0.5.0' -> '0.5.0'